### PR TITLE
fix warning deprecated #primary_key, added switch for  diesel_version…

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -184,10 +184,18 @@ pub fn parse(
                             ""
                         },
                     );
-                    str_model.push_str(&" ".repeat(indent_depth));
-                    str_model.push_str("#[primary_key(");
-                    str_model.push_str(&pks_list.join(", "));
-                    str_model.push_str(")]\n");
+                    if diesel_version == "2" {
+                        str_model.push_str(&" ".repeat(indent_depth));
+                        str_model.push_str("#[diesel(primary_key(");
+                        str_model.push_str(&pks_list.join(", "));
+                        str_model.push_str("))]\n");
+
+                    }else {
+                        str_model.push_str(&" ".repeat(indent_depth));
+                        str_model.push_str("#[primary_key(");
+                        str_model.push_str(&pks_list.join(", "));
+                        str_model.push_str(")]\n");
+                    }
                 }
             }
 


### PR DESCRIPTION
fix warning deprecated #primary_key, added switch for  diesel_version…and for v2 use new term #[diesel(primary_key()