### PR TITLE
Ignore `pub mod sql_types { ... }` submodule namespace

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -136,7 +136,7 @@ pub fn parse(
 
         if cmp.contains("#[") || cmp.contains("joinable!(") {
             //do nothing
-        } else if cmp.contains("pub mod ") {
+        } else if cmp.contains("pub mod ") && cmp.trim() != "pub mod sql_types {" {
             if is_schema {
                 str_model.push_str("\n}\n\n");
             }


### PR DESCRIPTION
When the Diesel-generated schema contains the following submodule
```rust
// @generated automatically by Diesel CLI.

pub mod sql_types {
    // Some custom SQL types here, but not tables!
}

// Some table definitions here
```
it makes `diesel_ext` panic (because of `index out of bounds`), and even after string indexing is fixed with #49 it will make `diesel_ext` to put all the model definitions inside the `sql_types` submodule, which, of course, is not what we want:
```rust
// Generated by diesel_ext

#![allow(unused)]
#![allow(clippy::all)]

pub mod sql_types {
    // Suddenly, model definitions are here now
}
```
It's a small hotfix, I consider it as a hack because it does not help to do proper module namespace parsing, but at least it helps to handle quite common Diesel schema definitions where you can often meet such `pub mod sql_types { ... }` submodule.

This combined with #49 will help to fix #47