### PR TITLE
modify table name for diesel v2

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -203,7 +203,7 @@ pub fn parse(
                 if diesel_version == "2" {
                     // add #[diesel(table_name = "name")]
                     str_model.push_str(&format!(
-                        "{}#[diesel(table_name = \"{}\")]\n",
+                        "{}#[diesel(table_name = {})]\n",
                         " ".repeat(indent_depth),
                         vec[0]
                     ));

--- a/test_data/expected_output/schema_with_tablename_derives.rs
+++ b/test_data/expected_output/schema_with_tablename_derives.rs
@@ -1,6 +1,6 @@
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(key))]
-#[diesel(table_name = "settings")]
+#[diesel(table_name = settings)]
 pub struct Setting {
     pub key: String,
     pub value: serde_json::Value,


### PR DESCRIPTION
## Background
The table name specification was changed from strings to modules in v2.

## What
Remove double quotes from output table names.

## Related issues
https://github.com/abbychau/diesel_cli_ext/issues/51