### PR TITLE
Adds flag to allow models to be generated with Rust styled struct fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,19 @@
 version = 3
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "diesel_cli_ext"
 version = "0.3.10"
 dependencies = [
+ "convert_case",
  "getopts",
  "toml",
 ]
@@ -33,6 +43,12 @@ checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "diesel_ext"
 path = "src/main.rs"
 
 [dependencies]
+convert_case = "0.6.0"
 getopts = "0.2"
 toml = "0.5.5"
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Model Options:
                         "table_name +Debug" --derive-mod "table_name2 -Debug"
     -d, --derive DERIVES
                         set struct derives
+    -r, --rust_styled_model_fields
+                        set struct field names to be styled according to Rust guidelines
 
 Proto Options:
     -t, --add-table-name 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,8 @@ fn main() {
         "add-table-name",
         "Add #[table_name = x] before structs",
     );
-    
+    opts.optflag("r", "rust_styled_model_fields", "When creating models fields, will use rust styled names instead of database styled names");
+
 
     opts.optflag("p", "proto", "Set as proto output");
     opts.optflag("i", "into_proto", "Set as into_proto output");
@@ -139,6 +140,8 @@ fn main() {
         return;
     }
     //print!("{:?}",matches.opt_defined("m"));
+
+    let rust_styled_fields = matches.opt_present("r");
 
     let mut type_mapping: HashMap<String, String> = HashMap::new();
 
@@ -211,7 +214,8 @@ fn main() {
         derive,
         matches.opt_present("t"),
         &mut type_mapping,
-        &diesel_version
+        &diesel_version,
+        rust_styled_fields,
     );
 
     //imported types

--- a/test_data/expected_output/schema_with_rust_style_fields.rs
+++ b/test_data/expected_output/schema_with_rust_style_fields.rs
@@ -1,0 +1,125 @@
+#[derive(Queryable, Debug)]
+pub struct UnitsOfMeasure {
+    pub id: u32,
+    #[diesel(column_name = "volumetricUnitId")]
+    pub volumetric_unit_id: Option<u32>,
+    #[diesel(column_name = "weightUnitId")]
+    pub weight_unit_id: Option<u32>,
+    pub number: Option<f64>,
+    #[diesel(column_name = "createdAt")]
+    pub created_at: Option<NaiveDateTime>,
+    #[diesel(column_name = "updatedAt")]
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct SomethingType {
+    pub id: u32,
+    pub value: String,
+    pub name: String,
+    pub active: bool,
+    #[diesel(column_name = "createdAt")]
+    pub created_at: Option<NaiveDateTime>,
+    #[diesel(column_name = "updatedAt")]
+    pub updated_at: Option<NaiveDateTime>,
+    pub inbound: bool,
+}
+
+#[derive(Queryable, Debug)]
+pub struct Something {
+    pub id: u32,
+    #[diesel(column_name = "somethingId")]
+    pub something_id: Option<u32>,
+    #[diesel(column_name = "somethingInOunces")]
+    pub something_in_ounces: f64,
+    pub total: f64,
+    #[diesel(column_name = "createdAt")]
+    pub created_at: Option<NaiveDateTime>,
+    #[diesel(column_name = "updatedAt")]
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct TextType {
+    pub id: i32,
+    pub tinytext: String,
+    #[diesel(column_name = "nullableTinytext")]
+    pub nullable_tinytext: Option<String>,
+    pub mediumtext: String,
+    #[diesel(column_name = "nullableMediumtext")]
+    pub nullable_mediumtext: Option<String>,
+    pub longtext: String,
+    #[diesel(column_name = "nullableLongtext")]
+    pub nullable_longtext: Option<String>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct NumericType {
+    pub id: i32,
+    pub double: f64,
+    #[diesel(column_name = "nullableDouble")]
+    pub nullable_double: Option<f64>,
+    pub tinyint: i8,
+    #[diesel(column_name = "nullableTinyint")]
+    pub nullable_tinyint: Option<i8>,
+    pub smallint: i16,
+    #[diesel(column_name = "nullableSmallint")]
+    pub nullable_smallint: Option<i16>,
+    pub bigint: i64,
+    #[diesel(column_name = "nullableBigint")]
+    pub nullable_bigint: Option<i64>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct UnsignedType {
+    pub id: i32,
+    #[diesel(column_name = "unsignedTinyint")]
+    pub unsigned_tinyint: u8,
+    #[diesel(column_name = "nullableUnsignedTinyint")]
+    pub nullable_unsigned_tinyint: Option<u8>,
+    #[diesel(column_name = "unsignedSmallint")]
+    pub unsigned_smallint: u16,
+    #[diesel(column_name = "nullableUnsignedSmallint")]
+    pub nullable_unsigned_smallint: Option<u16>,
+    pub bigint: u64,
+    #[diesel(column_name = "nullableBigint")]
+    pub nullable_bigint: Option<u64>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct BlobType {
+    pub id: i32,
+    pub blob: Vec<u8>,
+    #[diesel(column_name = "nullableBlob")]
+    pub nullable_blob: Option<Vec<u8>>,
+    pub tinyblob: Vec<u8>,
+    #[diesel(column_name = "nullableTinyblob")]
+    pub nullable_tinyblob: Option<Vec<u8>>,
+    pub mediumblob: Vec<u8>,
+    #[diesel(column_name = "nullableMediumblob")]
+    pub nullable_mediumblob: Option<Vec<u8>>,
+    pub longblob: Vec<u8>,
+    #[diesel(column_name = "nullableLongblob")]
+    pub nullable_longblob: Option<Vec<u8>>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct BinaryAndChar {
+    pub id: i32,
+    pub char: String,
+    pub varchar: String,
+    pub binary: Vec<u8>,
+    pub varbinary: Vec<u8>,
+}
+
+#[derive(Queryable, Debug)]
+pub struct UppercaseField {
+    #[diesel(column_name = "ID")]
+    pub id: i32,
+    #[diesel(column_name = "NAME")]
+    pub name: String,
+    #[diesel(column_name = "CREATED_AT")]
+    pub created_at: Option<NaiveDateTime>,
+    #[diesel(column_name = "UPDATED_AT")]
+    pub updated_at: Option<NaiveDateTime>,
+}

--- a/test_data/schema_with_rust_style_fields.rs
+++ b/test_data/schema_with_rust_style_fields.rs
@@ -56,13 +56,13 @@ table! {
 // CREATE TABLE numeric_types (
 //   `id` INT NOT NULL,
 //   `double` DOUBLE NOT NULL,
-//   `nullable_double` DOUBLE NULL,
+//   `nullableDouble` DOUBLE NULL,
 //   `tinyint` TINYINT NOT NULL,
 //   `nullableTinyint` TINYINT NULL,
 //   `smallint` SMALLINT NOT NULL,
 //   `nullableSmallint` SMALLINT NULL,
 //   `bigint` BIGINT NOT NULL,
-//   `nullableBigInt` BIGINT NULL,
+//   `nullable_bigint` BIGINT NULL,
 //   PRIMARY KEY (`id`));
 table! {
     numeric_types (id) {
@@ -120,5 +120,14 @@ table! {
         varchar -> Varchar,
         binary -> Binary,
         varbinary -> Varbinary,
+    }
+}
+
+table! {
+    uppercase_fields (id) {
+        ID -> Integer,
+        NAME -> Varchar,
+        CREATED_AT -> Nullable<Datetime>,
+        UPDATED_AT -> Nullable<Datetime>,
     }
 }


### PR DESCRIPTION
When the columns in the DB are not rust formatted, the tool today will take the formatting of the DB column name as is. While this doesn't break anything it does make the linter rather unhappy and requires additional work to remove lint issues. This change adds a flag to make the styling match the snake_case formatting per Rust style guides. 

For fields that are changed, it adds the diesel macro for specifying column names. For this, I did bring in convert_case to handle the case detection as without it I would have needed to replicate the majority of their solution for this. Happy to change anything in the PR as desired. 

Thanks for making this awesome extension, saved me a ton of time writing models for an existing DB. 