### PR TITLE
Pretty assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,15 @@ version = "0.3.13"
 dependencies = [
  "convert_case",
  "getopts",
+ "pretty_assertions",
  "toml",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "getopts"
@@ -27,6 +34,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -55,3 +72,9 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ toml = "0.5.5"
 [badges]
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "abbychau/diesel_cli_ext" }
+
+[dev-dependencies]
+pretty_assertions = "1.4.0"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -457,6 +457,7 @@ fn propercase(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     use std::io::prelude::*;
 


### PR DESCRIPTION
Replacing the default `assert_eq` with the one from [pretty assertions](https://crates.io/crates/pretty_assertions) makes it easier to analyze test case errors.

Before:
![image](https://github.com/abbychau/diesel_cli_ext/assets/125314669/8b84b0e2-c6ed-49c5-8336-2876b6a34451)

After:
![image](https://github.com/abbychau/diesel_cli_ext/assets/125314669/7c4fd746-5dae-4836-b3cd-51982e6726e4)

