### PR TITLE
Struct name override

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,9 @@ It contains 4 functions at this moment.
 `cargo install diesel_cli_ext`
 
 ## How to use
-First of all, `diesel print-schema > src/schema.rs` 
+First of all, `diesel print-schema > src/schema.rs`
 
-TL;DR: 
+TL;DR:
 
 ```
 Usage: target/debug/diesel_ext FILE [options]
@@ -36,17 +36,24 @@ Model Options:
                         This field adds use statements to the top of every
                         table! declaration. (can be set multiple times) e.g.
                         --import_types "diesel::sql_types::*"
+        --derive-mod "TABLENAME MODIFIER"
+                        (NOT ready)This field adds derives for certain tables.
+                        (can be set multiple times) e.g. --derive-mod
+                        "table_name +Debug" --derive-mod "table_name2 -Debug"
+    -n, --struct-name-override "STRUCT NAME OVERRIDE"
+                        This field overrides the generated struct name for
+                        certain tables. (can be set multiple times) e.g.
+                        --struct-name-override "foo bar"
+                        --struct-name-override "bar baz"
+
+Proto Options:
     -d, --derive DERIVES
                         set struct derives
     -t, --add-table-name 
                         Add #[table_name = x] before structs
-
-Proto Options:
-    -p, --proto         Set as proto output
-    -i, --into_proto    Set as into_proto output
-    -f, --from_proto    Set as from_proto output
-    -c, --class_name CLASS_NAME
-                        Set proto class name
+    -r, --rust_styled_model_fields 
+                        When creating models fields, will use rust styled
+                        names instead of database styled names
 ```
 
 (You can see it again by `diesel_ext --help`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,12 @@ fn main() {
         "(NOT ready)This field adds derives for certain tables. (can be set multiple times) e.g. --derive-mod \"table_name +Debug\" --derive-mod \"table_name2 -Debug\"",
         "\"TABLENAME MODIFIER\"",
     );
+    opts.optmulti(
+        "n",
+        "struct-name-override",
+        "This field overrides the generated struct name for certain tables. (can be set multiple times) e.g. --struct-name-override \"foo bar\" --struct-name-override \"bar baz\"",
+        "\"STRUCT NAME OVERRIDE\"",
+    );
     opts.optopt("d", "derive", "set struct derives", "DERIVES");
     opts.optflag(
         "t",
@@ -158,6 +164,15 @@ fn main() {
             model_type_mapping.insert(k[0].to_string(), k[1].to_string());
         }
     }
+
+    let mut struct_name_override: HashMap<String, String> = HashMap::new();
+    if matches.opt_present("n") {
+        for x in matches.opt_strs("n") {
+            let k: Vec<&str> = x.trim().split(' ').collect();
+            struct_name_override.insert(k[0].to_string(), k[1].to_string());
+        }
+    }
+
     let diesel_version = matches.opt_str("v").unwrap_or("2".to_string());
     if diesel_version != "1" && diesel_version != "2" {
         panic!("diesel_version must be 1 or 2");
@@ -223,6 +238,7 @@ fn main() {
         model_type_mapping,
         diesel_version,
         rust_styled_fields,
+        struct_name_override,
     });
 
     //imported types

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ fn print_usage(program: &str, opts: Options) {
 fn main() {
     //Read in
     let args: Vec<String> = env::args().collect();
-    let action;
     let mut model_derives: Option<String> = None;
     let mut class_name: String = "".to_string();
     let program = args[0].clone();
@@ -163,26 +162,26 @@ fn main() {
     if diesel_version != "1" && diesel_version != "2" {
         panic!("diesel_version must be 1 or 2");
     }
-    if matches.opt_present("m") {
-        action = "model";
+    let action = if matches.opt_present("m") {
         model_derives = matches.opt_str("d");
+        "model"
     } else if matches.opt_present("i") {
-        action = "into_proto";
         class_name = matches
             .opt_str("c")
             .unwrap_or_else(|| "class_name".to_string());
+        "into_proto"
     } else if matches.opt_present("f") {
-        action = "from_proto";
         class_name = matches
             .opt_str("c")
             .unwrap_or_else(|| "class_name".to_string());
+        "from_proto"
     } else if matches.opt_present("p") {
-        action = "proto";
+        "proto"
     } else {
         //default as m
-        action = "model";
         model_derives = matches.opt_str("d");
-    }
+        "model"
+    };
 
     let path = match matches.opt_str("s") {
         Some(file2) => file2,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -674,4 +674,19 @@ mod tests {
             file_get_contents("test_data/expected_output/schema_with_rust_style_fields.rs")
         );
     }
+
+    #[test]
+    fn build_with_struct_name_override() {
+        let parse_output = super::parse(ParseArguments {
+            contents: file_get_contents("test_data/schema_with_struct_name_override.rs"),
+            action: "model".into(),
+            diesel_version: "2".into(),
+            ..Default::default()
+        });
+        print!("a:{}", parse_output.str_model);
+        assert_eq!(
+            parse_output.str_model,
+            file_get_contents("test_data/expected_output/schema_with_struct_name_override.rs")
+        );
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -19,7 +19,6 @@ pub struct ParseOutput {
     pub type_jsonb: bool,
 }
 
-#[derive(Default)]
 pub struct ParseArguments {
     pub contents: String,
     pub action: String,
@@ -29,6 +28,21 @@ pub struct ParseArguments {
     pub diesel_version: String,
     pub rust_styled_fields: bool,
     pub struct_name_override: HashMap<String, String>,
+}
+
+impl Default for ParseArguments {
+    fn default() -> Self {
+        Self {
+            contents: Default::default(),
+            action: Default::default(),
+            model_derives: Default::default(),
+            add_table_name: Default::default(),
+            model_type_mapping: Default::default(),
+            diesel_version: "2".into(),
+            rust_styled_fields: Default::default(),
+            struct_name_override: Default::default(),
+        }
+    }
 }
 
 pub fn parse(args: ParseArguments) -> ParseOutput {
@@ -485,7 +499,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             action: "model".into(),
             contents: file_get_contents("test_data/schema.rs"),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         println!("str_proto shows as follow:\n{}", parse_output.str_proto);
@@ -513,7 +526,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_localmodded.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         println!("{}", parse_output.str_model);
@@ -535,7 +547,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_ip_bytea.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("{}", parse_output.str_model);
@@ -557,7 +568,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_tab.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("{}", parse_output.str_model);
@@ -570,7 +580,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_time.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("{}", parse_output.str_model);
@@ -583,7 +592,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_ies.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("{}", parse_output.str_model);
@@ -598,7 +606,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("{}", parse_output.str_model);
@@ -609,7 +616,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_uuid.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         assert!(parse_output.type_uuid);
@@ -624,7 +630,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_mysql.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("a:{}", parse_output.str_model);
@@ -639,7 +644,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_jsonb.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             ..Default::default()
         });
         print!("a:{}", parse_output.str_model);
@@ -654,7 +658,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_tablename_derives.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             add_table_name: true,
             ..Default::default()
         });
@@ -670,7 +673,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_rust_style_fields.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             rust_styled_fields: true,
             ..Default::default()
         });
@@ -686,7 +688,6 @@ mod tests {
         let parse_output = super::parse(ParseArguments {
             contents: file_get_contents("test_data/schema_with_struct_name_override.rs"),
             action: "model".into(),
-            diesel_version: "2".into(),
             add_table_name: true,
             struct_name_override: HashMap::from([(
                 "my_table".to_string(),

--- a/test_data/expected_output/schema_with_struct_name_override.rs
+++ b/test_data/expected_output/schema_with_struct_name_override.rs
@@ -1,0 +1,5 @@
+#[derive(Queryable, Debug)]
+#[diesel(table_name = my_table)]
+pub struct MyOverriddenTable {
+    pub id: i32,
+}

--- a/test_data/schema_with_struct_name_override.rs
+++ b/test_data/schema_with_struct_name_override.rs
@@ -1,0 +1,5 @@
+table! {
+    my_table (id) {
+        id -> Int4,
+    }
+}


### PR DESCRIPTION
I had some problems with the `propercase` function converting my table `series` to a struct with the name `Sery`. This PR makes it possible to bypass the `propercase` function by passing the `struct-name-override` flag.

This schema is used in the following examples:
```rs
diesel::table! {
    series (id) {
        id -> Int4,
        title_id -> Int4,
        created_at -> Timestamp,
        updated_at -> Timestamp,
    }
}
```

Example usage:
```sh
diesel_ext --model --add-table-name --struct-name-override "series Series"
```

Output:
```rs
#[derive(Queryable, Debug)]
#[diesel(table_name = series)]
pub struct Series {
    pub id: i32,
    pub title_id: i32,
    pub created_at: NaiveDateTime,
    pub updated_at: NaiveDateTime,
}
```

If the flag is not provided the same old behavious is used.

Example:
```sh
diesel_ext --model --add-table-name
```

Output:
```rs
#[derive(Queryable, Debug)]
#[diesel(table_name = series)]
pub struct Sery {
    pub id: i32,
    pub title_id: i32,
    pub created_at: NaiveDateTime,
    pub updated_at: NaiveDateTime,
}
```

closes #32 